### PR TITLE
feat: Add 'version' and 'about' commands for displaying interpreter metadata (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ The format is based on [Semantic Versioning](https://semver.org/).
 
 - Merged and closed issue #12
 
+- Added support for `version` and `about` commands to display interpreter metadata (#16)
+
 ## 🟡 Work in Progress
 
 - Wiki Home Page draft not yet created

--- a/src/config.py
+++ b/src/config.py
@@ -1,0 +1,11 @@
+# src/config.py
+"""
+Configuration and constants for the TigerByte Interpreter.
+"""
+
+# --- Core Metadata ---
+VERSION = "v0.1.0"
+REPO_URL = "https://github.com/bijiyiqi2017/TigerByte"
+
+# --- Interpreter Settings ---
+# Future settings (e.g., DEFAULT_ENCODING, MAX_LINES) can go here

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -11,6 +11,7 @@ Date: October 2025
 License: MIT
 """
 from debug import Debugger
+from config import VERSION, REPO_URL
 import sys
 import os
 import argparse
@@ -81,14 +82,22 @@ def run_tigerbyte_file(filepath: str, debug_enabled: bool = False):
     debugger.log("Execution finished.")
 
 
-def execute_command(command: str, debugger: Debugger):
+def execute_command(command: str, debugger):
     """
     Basic command executor.
-    Supports: print "<message>"
+    Supports: print, version, about
     Future: feed, chase, roar, etc.
     """
+    
+    clean_command = command.strip().lower() # Normalize command input
 
-    if command.startswith("print "):
+    if clean_command == "version" or clean_command == "about":
+        # Handle the version/about command
+        print(f"🐯 TigerByte Interpreter {VERSION}")
+        print("Developed by the TigerByte Community")
+        print(f"Repository: {REPO_URL}")
+
+    elif command.startswith("print "):
         # Extract message text
         message = command[len("print "):].strip().strip('"').strip("'")
         print(message)
@@ -101,23 +110,47 @@ def execute_command(command: str, debugger: Debugger):
 def main():
     """CLI entry point with argument parsing."""
     parser = argparse.ArgumentParser(
-        description="🐯 TigerByte Interpreter v0.1 - Executes .tb files."
+        description="🐯 TigerByte Interpreter v0.1 - Executes .tb files. Use '--version' for info.",
     )
+
+    # --- CLI VERSION FLAG (THIS IS THE KEY FIX) ---
+    # When this flag is used, argparse will print the version and EXIT before checking for positional arguments.
+    parser.add_argument(
+        '--version',
+        action='version',
+        version=f'TigerByte Interpreter {VERSION}\nRepository: {REPO_URL}',
+        help="Show program's version number and exit."
+    )
+    # --- END VERSION FLAG ---
+
     parser.add_argument(
         'filepath',
+        nargs='?',           # Makes the argument OPTIONAL (0 or 1 argument)
+        default=None,
         help="Path to the TigerByte (.tb) script to run."
     )
     parser.add_argument(
         '--debug',
-        action='store_true', # Sets args.debug to True if flag is present
+        action='store_true',
         help="Enable debug mode to show execution steps."
     )
 
     # Parse the arguments provided from the command line
     args = parser.parse_args()
 
-    # Call the main execution function, passing the debug flag status
-    run_tigerbyte_file(args.filepath, debug_enabled=args.debug)
+    # --- LOGIC TO HANDLE NO FILEPATH (Assuming --version wasn't used, as it exits immediately) ---
+
+    if args.filepath:
+        # 1. If a filepath is provided, run the file.
+        run_tigerbyte_file(args.filepath, debug_enabled=args.debug)
+    
+    elif not args.filepath:
+        # 2. If NO filepath is provided, print the version/info directly.
+        # This handles the case where the user runs 'python interpreter.py' with no arguments.
+        print(f"🐯 TigerByte Interpreter {VERSION}")
+        print("Developed by the TigerByte Community")
+        print(f"Repository: {REPO_URL}")
+        print("\nNote: To run a script, use: python src/interpreter.py <filepath>")
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## 🐯 TigerByte Pull Request

**Related Issue:** Fixes #16

### 🧠 What This PR Does
This PR implements the **`version` and `about` commands** to display core interpreter metadata. It also introduces the standard **`--version` CLI flag** for quick information and fixes a bug in argument parsing.

### 🐾 Why It Matters
This is a core quality-of-life feature that makes the interpreter more professional and user-friendly by:
* Allowing users to quickly check the interpreter's version and repository details (`tiger version`).
* Centralizing key configuration (VERSION, REPO\_URL) in a dedicated `src/config.py` file, improving maintainability.
* **Fixing** a flaw in the `argparse` setup that prevented the interpreter from running without a required `filepath` positional argument.

### 🛠️ Implementation Notes
-   **Files Changed:** `src/interpreter.py`, `src/config.py` (New File), `contributors.json`, `CHANGELOG.md`
-   **Key Decisions:**
    1.  **Version Constant:** Created `src/config.py` to store `VERSION` and `REPO_URL`.
    2.  **CLI Flag:** Implemented the standard `--version` flag directly in `argparse` using `action='version'` so the program prints info and exits cleanly.
    3.  **Command Handling:** Updated `execute_command` to print the metadata when it sees `version` or `about` as a command.
    4.  **Argparse Fix:** Corrected the `main()` function's `argparse` usage to allow the `--version` flag to run without requiring a `filepath`.

### ✅ Checklist
- [x] Code runs locally and tests (if any) pass
- [x] Documentation or comments updated where relevant
- [x] I updated the changelog if the change is user-visible
- [ ] I added a short entry to `example.tb` or examples if appropriate *(Not applicable, as this feature is tested via CLI flags, not in a script)*
- [x] I’ve roared in celebration after saving the file 🐅

### 💬 Notes for Reviewers
The CLI can now be tested in two ways:
1.  **Standard CLI Flag:** `python src/interpreter.py --version` (Should print version and exit).
2.  **No Arguments:** `python src/interpreter.py` (Should print version/info because the `filepath` is now optional).

---

A screenshot for issue verified:
<img width="1438" height="379" alt="image" src="https://github.com/user-attachments/assets/ec78ac65-183b-42c0-8e62-22ff21d6001c" />
