### PR TITLE
feat(banner): build modular startup banner program

### DIFF
--- a/src/banners.py
+++ b/src/banners.py
@@ -1,0 +1,52 @@
+import random
+from pathlib import Path
+
+# Define the path to the banners directory (relative to the project root)
+# We assume banners from Issue #25 will be placed in 'assets/banners/'
+BANNER_DIR = Path("assets/banners")
+
+def load_all_banners():
+    """
+    Finds all .txt banner files in the banner directory.
+    Returns a list of Path objects.
+    """
+    if not BANNER_DIR.is_dir():
+        print(f"Warning: Banner directory not found at {BANNER_DIR}")
+        return []  # Return empty list if directory doesn't exist
+
+    # Find all files ending in .txt
+    banner_files = list(BANNER_DIR.glob("*.txt"))
+    return banner_files
+
+def get_banner_content(banner_path):
+    """Reads and returns the content of a specific banner file."""
+    try:
+        with open(banner_path, 'r', encoding='utf-8') as f:
+            return f.read()
+    except Exception as e:
+        return f"[Error loading banner: {e}]"
+
+def display_random_banner():
+    """Selects a random banner from the directory and prints it."""
+    banners = load_all_banners()
+
+    if not banners:
+        # Fallback text if no banners are found
+        print("="*30)
+        print(" Welcome to TigerByte! ")
+        print("="*30)
+        return
+
+    random_banner_path = random.choice(banners)
+    print(get_banner_content(random_banner_path))
+
+def display_banner_by_name(file_name):
+    """Selects a specific banner by name (e.g., 'banner1.txt') and prints it."""
+    banner_path = BANNER_DIR / file_name
+
+    if not banner_path.exists():
+        print(f"Error: Banner '{file_name}' not found.")
+        # Fallback to a random one
+        display_random_banner()
+    else:
+        print(get_banner_content(banner_path))

--- a/src/interpreter.py
+++ b/src/interpreter.py
@@ -10,6 +10,9 @@ Author: Rangala Raj Kumar
 Date: 27 October 2025
 License: MIT
 """
+
+
+from .banners import display_random_banner, display_banner_by_name
 from debug import Debugger
 from config import VERSION, REPO_URL
 import sys
@@ -412,8 +415,31 @@ def run_tigerbyte_file(filepath: str, debug_enabled: bool = False):
 
 def main():
     parser = argparse.ArgumentParser(description="🐯 TigerByte Interpreter")
+    
+    # 1. ADD THE NEW BANNER ARGUMENT
+    parser.add_argument(
+        '--banner', 
+        type=str, 
+        nargs='?', 
+        const='random', 
+        default='random', 
+        help="Specify a banner name (e.g., 'banner1.txt') or 'none' to hide it. Default is 'random'."
+    )
+    
+    # 2. KEEP THE ORIGINAL FILE ARGUMENT
     parser.add_argument("file", help="path to .tb file")
-    args = parser.parse_args()
+
+    # 3. USE parse_known_args() TO ALLOW OTHER ARGS
+    args, _ = parser.parse_known_args()
+
+    # 4. ADD THE BANNER DISPLAY LOGIC
+    if args.banner != 'none':
+        if args.banner == 'random':
+            display_random_banner()
+        else:
+            display_banner_by_name(args.banner)
+            
+    # 5. KEEP THE ORIGINAL CALL TO RUN THE FILE
     run_tigerbyte_file(args.file)
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 🐅 TigerByte Pull Request

**Related Issue:** Fixes #26 (Part of Epic #24)

### What This PR Does
This PR builds the core technical framework for the modular startup banner system. It adds a new `banners.py` module responsible for loading and displaying banners, and integrates it into the main `interpreter.py` entry point.

### Why It Matters
This change fulfills the main technical goal of the startup banner epic. It provides a clean, modular way to handle banners and adds the "stretch goal" feature of letting users select a specific banner (or no banner) using a command-line argument (`--banner`).

### Implementation Notes
- **Files changed:**
    - `src/banners.py` (New file): Contains all logic for loading banners from `assets/banners/` and displaying them. Includes `display_random_banner()` and `display_banner_by_name()`.
    - `src/interpreter.py` (Modified): Imports the new banner module and uses `argparse` to handle the `--banner` flag at startup.
- **Key decisions:** Used `argparse.parse_known_args()` to ensure the new `--banner` flag doesn't interfere with the existing file path argument.

### Checklist
- [x] Code runs locally and tests (if any) pass
- [x] Documentation or comments updated where relevant